### PR TITLE
[pr] Refactor CRUD Layer into Structured Application Services with DTO Relocation

### DIFF
--- a/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/AssignmentAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/AssignmentAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.ProjectManagement;
+using SeeSpec.Services.AssignmentService.DTO;
+
+namespace SeeSpec.Services.AssignmentService
+{
+    [AbpAuthorize]
+    public class AssignmentAppService : AsyncCrudAppService<Assignment, AssignmentDto, Guid, PagedAndSortedResultRequestDto, AssignmentDto, AssignmentDto>, IAssignmentAppService
+    {
+        public AssignmentAppService(IRepository<Assignment, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/DTO/AssignmentDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/DTO/AssignmentDto.cs
@@ -1,10 +1,11 @@
 using System;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.ProjectManagement;
 
-namespace SeeSpec.Domains.ProjectManagement.Dtos
+namespace SeeSpec.Services.AssignmentService.DTO
 {
-    [AutoMapFrom(typeof(Assignment))]
+    [AutoMap(typeof(Assignment))]
     public class AssignmentDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -18,3 +19,4 @@ namespace SeeSpec.Domains.ProjectManagement.Dtos
         public DateTime JoinedAt { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/IAssignmentAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/AssignmentService/IAssignmentAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.AssignmentService.DTO;
+
+namespace SeeSpec.Services.AssignmentService
+{
+    public interface IAssignmentAppService : IAsyncCrudAppService<AssignmentDto, Guid, PagedAndSortedResultRequestDto, AssignmentDto, AssignmentDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/BackendService/BackendAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/BackendService/BackendAppService.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.ProjectManagement;
+using SeeSpec.Services.BackendService.DTO;
+
+namespace SeeSpec.Services.BackendService
+{
+    [AbpAuthorize]
+    public class BackendAppService : AsyncCrudAppService<Backend, BackendDto, Guid, PagedAndSortedResultRequestDto, BackendDto, BackendDto>, IBackendAppService
+    {
+        public BackendAppService(IRepository<Backend, Guid> repository)
+            : base(repository)
+        {
+        }
+
+        protected override IQueryable<Backend> CreateFilteredQuery(PagedAndSortedResultRequestDto input)
+        {
+            var query = base.CreateFilteredQuery(input);
+
+            if (AbpSession.TenantId.HasValue)
+            {
+                query = query.Where(x => x.TenantId == AbpSession.TenantId.Value);
+            }
+
+            return query;
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/BackendService/DTO/BackendDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/BackendService/DTO/BackendDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.ProjectManagement;
 
-namespace SeeSpec.Domains.ProjectManagement.Dtos
+namespace SeeSpec.Services.BackendService.DTO
 {
-    [AutoMapFrom(typeof(Backend))]
+    [AutoMap(typeof(Backend))]
     public class BackendDto : EntityDto<Guid>
     {
         public int TenantId { get; set; }
@@ -34,3 +35,4 @@ namespace SeeSpec.Domains.ProjectManagement.Dtos
         public string RepositoryUrl { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/BackendService/IBackendAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/BackendService/IBackendAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.BackendService.DTO;
+
+namespace SeeSpec.Services.BackendService
+{
+    public interface IBackendAppService : IAsyncCrudAppService<BackendDto, Guid, PagedAndSortedResultRequestDto, BackendDto, BackendDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/DTO/DiagramElementDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/DTO/DiagramElementDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.SpecManagement;
 
-namespace SeeSpec.Domains.SpecManagement.Dtos
+namespace SeeSpec.Services.DiagramElementService.DTO
 {
-    [AutoMapFrom(typeof(DiagramElement))]
+    [AutoMap(typeof(DiagramElement))]
     public class DiagramElementDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -26,3 +27,4 @@ namespace SeeSpec.Domains.SpecManagement.Dtos
         public string MetadataJson { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/DiagramElementAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/DiagramElementAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.SpecManagement;
+using SeeSpec.Services.DiagramElementService.DTO;
+
+namespace SeeSpec.Services.DiagramElementService
+{
+    [AbpAuthorize]
+    public class DiagramElementAppService : AsyncCrudAppService<DiagramElement, DiagramElementDto, Guid, PagedAndSortedResultRequestDto, DiagramElementDto, DiagramElementDto>, IDiagramElementAppService
+    {
+        public DiagramElementAppService(IRepository<DiagramElement, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/IDiagramElementAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/DiagramElementService/IDiagramElementAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.DiagramElementService.DTO;
+
+namespace SeeSpec.Services.DiagramElementService
+{
+    public interface IDiagramElementAppService : IAsyncCrudAppService<DiagramElementDto, Guid, PagedAndSortedResultRequestDto, DiagramElementDto, DiagramElementDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/DTO/GenerationSnapshotDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/DTO/GenerationSnapshotDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.CodingManagement;
 
-namespace SeeSpec.Domains.CodingManagement.Dtos
+namespace SeeSpec.Services.GenerationSnapshotService.DTO
 {
-    [AutoMapFrom(typeof(GenerationSnapshot))]
+    [AutoMap(typeof(GenerationSnapshot))]
     public class GenerationSnapshotDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -26,3 +27,4 @@ namespace SeeSpec.Domains.CodingManagement.Dtos
         public string PromptSent { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/GenerationSnapshotAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/GenerationSnapshotAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.CodingManagement;
+using SeeSpec.Services.GenerationSnapshotService.DTO;
+
+namespace SeeSpec.Services.GenerationSnapshotService
+{
+    [AbpAuthorize]
+    public class GenerationSnapshotAppService : AsyncCrudAppService<GenerationSnapshot, GenerationSnapshotDto, Guid, PagedAndSortedResultRequestDto, GenerationSnapshotDto, GenerationSnapshotDto>, IGenerationSnapshotAppService
+    {
+        public GenerationSnapshotAppService(IRepository<GenerationSnapshot, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/IGenerationSnapshotAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/GenerationSnapshotService/IGenerationSnapshotAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.GenerationSnapshotService.DTO;
+
+namespace SeeSpec.Services.GenerationSnapshotService
+{
+    public interface IGenerationSnapshotAppService : IAsyncCrudAppService<GenerationSnapshotDto, Guid, PagedAndSortedResultRequestDto, GenerationSnapshotDto, GenerationSnapshotDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/NotesService/DTO/NotesDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/NotesService/DTO/NotesDto.cs
@@ -2,11 +2,12 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.ProjectManagement;
 
-namespace SeeSpec.Domains.ProjectManagement.Dtos
+namespace SeeSpec.Services.NotesService.DTO
 {
-    [AutoMapFrom(typeof(Note))]
-    public class NoteDto : EntityDto<Guid>
+    [AutoMap(typeof(Note))]
+    public class NotesDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
 
@@ -26,3 +27,4 @@ namespace SeeSpec.Domains.ProjectManagement.Dtos
         public string OutcomeSummary { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/NotesService/INotesAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/NotesService/INotesAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.NotesService.DTO;
+
+namespace SeeSpec.Services.NotesService
+{
+    public interface INotesAppService : IAsyncCrudAppService<NotesDto, Guid, PagedAndSortedResultRequestDto, NotesDto, NotesDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/NotesService/NotesAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/NotesService/NotesAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.ProjectManagement;
+using SeeSpec.Services.NotesService.DTO;
+
+namespace SeeSpec.Services.NotesService
+{
+    [AbpAuthorize]
+    public class NotesAppService : AsyncCrudAppService<Note, NotesDto, Guid, PagedAndSortedResultRequestDto, NotesDto, NotesDto>, INotesAppService
+    {
+        public NotesAppService(IRepository<Note, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/DTO/SectionDependencyDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/DTO/SectionDependencyDto.cs
@@ -1,10 +1,11 @@
 using System;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.SpecManagement;
 
-namespace SeeSpec.Domains.SpecManagement.Dtos
+namespace SeeSpec.Services.SectionDependencyService.DTO
 {
-    [AutoMapFrom(typeof(SectionDependency))]
+    [AutoMap(typeof(SectionDependency))]
     public class SectionDependencyDto : EntityDto<Guid>
     {
         public Guid FromSectionId { get; set; }
@@ -14,3 +15,4 @@ namespace SeeSpec.Domains.SpecManagement.Dtos
         public SectionDependencyType DependencyType { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/ISectionDependencyAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/ISectionDependencyAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.SectionDependencyService.DTO;
+
+namespace SeeSpec.Services.SectionDependencyService
+{
+    public interface ISectionDependencyAppService : IAsyncCrudAppService<SectionDependencyDto, Guid, PagedAndSortedResultRequestDto, SectionDependencyDto, SectionDependencyDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/SectionDependencyAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionDependencyService/SectionDependencyAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.SpecManagement;
+using SeeSpec.Services.SectionDependencyService.DTO;
+
+namespace SeeSpec.Services.SectionDependencyService
+{
+    [AbpAuthorize]
+    public class SectionDependencyAppService : AsyncCrudAppService<SectionDependency, SectionDependencyDto, Guid, PagedAndSortedResultRequestDto, SectionDependencyDto, SectionDependencyDto>, ISectionDependencyAppService
+    {
+        public SectionDependencyAppService(IRepository<SectionDependency, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/DTO/SectionItemDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/DTO/SectionItemDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.SpecManagement;
 
-namespace SeeSpec.Domains.SpecManagement.Dtos
+namespace SeeSpec.Services.SectionItemService.DTO
 {
-    [AutoMapFrom(typeof(SectionItem))]
+    [AutoMap(typeof(SectionItem))]
     public class SectionItemDto : EntityDto<Guid>
     {
         public Guid SpecSectionId { get; set; }
@@ -22,3 +23,4 @@ namespace SeeSpec.Domains.SpecManagement.Dtos
         public SectionItemType ItemType { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/ISectionItemAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/ISectionItemAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.SectionItemService.DTO;
+
+namespace SeeSpec.Services.SectionItemService
+{
+    public interface ISectionItemAppService : IAsyncCrudAppService<SectionItemDto, Guid, PagedAndSortedResultRequestDto, SectionItemDto, SectionItemDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/SectionItemAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SectionItemService/SectionItemAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.SpecManagement;
+using SeeSpec.Services.SectionItemService.DTO;
+
+namespace SeeSpec.Services.SectionItemService
+{
+    [AbpAuthorize]
+    public class SectionItemAppService : AsyncCrudAppService<SectionItem, SectionItemDto, Guid, PagedAndSortedResultRequestDto, SectionItemDto, SectionItemDto>, ISectionItemAppService
+    {
+        public SectionItemAppService(IRepository<SectionItem, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/DTO/SpecSectionDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/DTO/SpecSectionDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.SpecManagement;
 
-namespace SeeSpec.Domains.SpecManagement.Dtos
+namespace SeeSpec.Services.SpecSectionService.DTO
 {
-    [AutoMapFrom(typeof(SpecSection))]
+    [AutoMap(typeof(SpecSection))]
     public class SpecSectionDto : EntityDto<Guid>
     {
         public Guid SpecId { get; set; }
@@ -32,3 +33,4 @@ namespace SeeSpec.Domains.SpecManagement.Dtos
         public int Version { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/ISpecSectionAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/ISpecSectionAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.SpecSectionService.DTO;
+
+namespace SeeSpec.Services.SpecSectionService
+{
+    public interface ISpecSectionAppService : IAsyncCrudAppService<SpecSectionDto, Guid, PagedAndSortedResultRequestDto, SpecSectionDto, SpecSectionDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/SpecSectionAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecSectionService/SpecSectionAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.SpecManagement;
+using SeeSpec.Services.SpecSectionService.DTO;
+
+namespace SeeSpec.Services.SpecSectionService
+{
+    [AbpAuthorize]
+    public class SpecSectionAppService : AsyncCrudAppService<SpecSection, SpecSectionDto, Guid, PagedAndSortedResultRequestDto, SpecSectionDto, SpecSectionDto>, ISpecSectionAppService
+    {
+        public SpecSectionAppService(IRepository<SpecSection, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecService/DTO/SpecDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecService/DTO/SpecDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.SpecManagement;
 
-namespace SeeSpec.Domains.SpecManagement.Dtos
+namespace SeeSpec.Services.SpecService.DTO
 {
-    [AutoMapFrom(typeof(Spec))]
+    [AutoMap(typeof(Spec))]
     public class SpecDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -21,3 +22,4 @@ namespace SeeSpec.Domains.SpecManagement.Dtos
         public SpecStatus Status { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecService/ISpecAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecService/ISpecAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.SpecService.DTO;
+
+namespace SeeSpec.Services.SpecService
+{
+    public interface ISpecAppService : IAsyncCrudAppService<SpecDto, Guid, PagedAndSortedResultRequestDto, SpecDto, SpecDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/SpecService/SpecAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/SpecService/SpecAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.SpecManagement;
+using SeeSpec.Services.SpecService.DTO;
+
+namespace SeeSpec.Services.SpecService
+{
+    [AbpAuthorize]
+    public class SpecAppService : AsyncCrudAppService<Spec, SpecDto, Guid, PagedAndSortedResultRequestDto, SpecDto, SpecDto>, ISpecAppService
+    {
+        public SpecAppService(IRepository<Spec, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TaskService/DTO/TaskDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TaskService/DTO/TaskDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.ProjectManagement;
 
-namespace SeeSpec.Domains.ProjectManagement.Dtos
+namespace SeeSpec.Services.TaskService.DTO
 {
-    [AutoMapFrom(typeof(Task))]
+    [AutoMap(typeof(Task))]
     public class TaskDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -32,3 +33,4 @@ namespace SeeSpec.Domains.ProjectManagement.Dtos
         public DateTime? DueAt { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TaskService/ITaskAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TaskService/ITaskAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.TaskService.DTO;
+
+namespace SeeSpec.Services.TaskService
+{
+    public interface ITaskAppService : IAsyncCrudAppService<TaskDto, Guid, PagedAndSortedResultRequestDto, TaskDto, TaskDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TaskService/TaskAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TaskService/TaskAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using ProjectTask = SeeSpec.Domains.ProjectManagement.Task;
+using SeeSpec.Services.TaskService.DTO;
+
+namespace SeeSpec.Services.TaskService
+{
+    [AbpAuthorize]
+    public class TaskAppService : AsyncCrudAppService<ProjectTask, TaskDto, Guid, PagedAndSortedResultRequestDto, TaskDto, TaskDto>, ITaskAppService
+    {
+        public TaskAppService(IRepository<ProjectTask, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TeamService/DTO/TeamDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TeamService/DTO/TeamDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using SeeSpec.Domains.ProjectManagement;
 
-namespace SeeSpec.Domains.ProjectManagement.Dtos
+namespace SeeSpec.Services.TeamService.DTO
 {
-    [AutoMapFrom(typeof(Team))]
+    [AutoMap(typeof(Team))]
     public class TeamDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -18,3 +19,4 @@ namespace SeeSpec.Domains.ProjectManagement.Dtos
         public string Description { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TeamService/ITeamAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TeamService/ITeamAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.TeamService.DTO;
+
+namespace SeeSpec.Services.TeamService
+{
+    public interface ITeamAppService : IAsyncCrudAppService<TeamDto, Guid, PagedAndSortedResultRequestDto, TeamDto, TeamDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/TeamService/TeamAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/TeamService/TeamAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.ProjectManagement;
+using SeeSpec.Services.TeamService.DTO;
+
+namespace SeeSpec.Services.TeamService
+{
+    [AbpAuthorize]
+    public class TeamAppService : AsyncCrudAppService<Team, TeamDto, Guid, PagedAndSortedResultRequestDto, TeamDto, TeamDto>, ITeamAppService
+    {
+        public TeamAppService(IRepository<Team, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/DTO/ValidationResultDto.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/DTO/ValidationResultDto.cs
@@ -2,10 +2,11 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using Abp.Application.Services.Dto;
 using Abp.AutoMapper;
+using CodingValidationResult = SeeSpec.Domains.CodingManagement.ValidationResult;
 
-namespace SeeSpec.Domains.CodingManagement.Dtos
+namespace SeeSpec.Services.ValidationResultService.DTO
 {
-    [AutoMapFrom(typeof(ValidationResult))]
+    [AutoMap(typeof(CodingValidationResult))]
     public class ValidationResultDto : EntityDto<Guid>
     {
         public Guid BackendId { get; set; }
@@ -24,3 +25,4 @@ namespace SeeSpec.Domains.CodingManagement.Dtos
         public string DetailsJson { get; set; }
     }
 }
+

--- a/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/IValidationResultAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/IValidationResultAppService.cs
@@ -1,0 +1,12 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using SeeSpec.Services.ValidationResultService.DTO;
+
+namespace SeeSpec.Services.ValidationResultService
+{
+    public interface IValidationResultAppService : IAsyncCrudAppService<ValidationResultDto, Guid, PagedAndSortedResultRequestDto, ValidationResultDto, ValidationResultDto>
+    {
+    }
+}
+

--- a/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/ValidationResultAppService.cs
+++ b/aspnet-core/src/SeeSpec.Application/Services/ValidationResultService/ValidationResultAppService.cs
@@ -1,0 +1,20 @@
+using System;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using SeeSpec.Domains.CodingManagement;
+using SeeSpec.Services.ValidationResultService.DTO;
+
+namespace SeeSpec.Services.ValidationResultService
+{
+    [AbpAuthorize]
+    public class ValidationResultAppService : AsyncCrudAppService<ValidationResult, ValidationResultDto, Guid, PagedAndSortedResultRequestDto, ValidationResultDto, ValidationResultDto>, IValidationResultAppService
+    {
+        public ValidationResultAppService(IRepository<ValidationResult, Guid> repository)
+            : base(repository)
+        {
+        }
+    }
+}
+


### PR DESCRIPTION
## Linked Issue
Closes #27 

## Summary
This PR introduces a structured application service layer under `SeeSpec.Application/Services` and refactors existing CRUD logic to follow the agreed service template. DTOs have been moved out of `SeeSpec.Core` and colocated with their respective services to enforce clean layering.

## Changes Made

### Application Service Structure
Created application services using the standard template for the following domains:

#### ProjectManagement
- BackendService
- TeamService
- AssignmentService
- TaskService
- NotesService

#### SpecManagement
- SpecService
- SpecSectionService
- SectionItemService
- SectionDependencyService
- DiagramElementService

#### CodingManagement
- GenerationSnapshotService
- ValidationResultService

Each service includes:
- I{Entity}AppService.cs
- {Entity}AppService.cs
- DTO/{Entity}Dto.cs

### DTO Refactor
- Moved DTOs out of `SeeSpec.Core`
- DTOs now live in `SeeSpec.Application/Services/{ServiceName}/DTO`
- Updated namespaces to align with folder structure
- Removed temporary `SeeSpec.Application/Domains/...` folders

### Naming and Consistency
- Aligned service and DTO naming with the agreed template
- NotesService follows the standardized naming:
  - INotesAppService.cs
  - NotesAppService.cs
  - NotesDto.cs
- Ensured namespaces match physical structure for maintainability

### Explicit Non-Changes
- No application services were created for non-existent entities
- No CodingStandardService was added
- No API controllers or endpoints were introduced

## Purpose
To establish a consistent, explicit application service layer that:
- Enforces clean architectural boundaries
- Prepares the system for authorization and API exposure
- Improves discoverability and maintainability of backend services
- Keeps domain entities free of application concerns

## Verification
- Solution builds successfully
- All services compile and resolve dependencies
- DTOs are no longer referenced from `SeeSpec.Core`
- Namespaces and folder structure align

## Checklist
- [x] Application services created per entity
- [x] DTOs moved out of Core
- [x] Folder and namespace structure standardized
- [x] No unintended domain or persistence changes
``